### PR TITLE
getting rid of `mixed content` warning

### DIFF
--- a/notes/bacon.html
+++ b/notes/bacon.html
@@ -74,7 +74,7 @@
 
   							<td width="33%">
     							<div style="text-align: center;">
-  									<img src="http://uploads2.wikiart.org/images/chaim-soutine/carcass-of-beef(1).jpg!Blog.jpg" style="width: 90%; margin-top: 5px; margin-bottom: 0px"></img>
+  									<img src="https://uploads2.wikiart.org/images/chaim-soutine/carcass-of-beef(1).jpg!Blog.jpg" style="width: 90%; margin-top: 5px; margin-bottom: 0px"></img>
   									<span class="subheader" style="font-size: 12px">
   										Carcass of Beef<br/>Chaim Soutine, 1926.<br/> Oil
   									</span>


### PR DESCRIPTION
Was reading your blog and noticed the mixed content warning in the console because of fetching an HTTP resource over HTTPS content.

By the way, very very nice blog.